### PR TITLE
Fix block usage tracking in PieceNew

### DIFF
--- a/Odc.mod
+++ b/Odc.mod
@@ -184,11 +184,12 @@ BEGIN
     p.ofs := b.used;
 
     IF size >= LEN(b.data) - b.used THEN
+      DEC(size, LEN(b.data) - b.used);
       b.used := LEN(b.data)
     ELSE
-      INC(b.used, (LEN(b.data) - b.used))
+      INC(b.used, size);
+      size := 0
     END;
-    DEC(size, LEN(b.data) - b.used);
 
     WHILE ok & (size >= LEN(b.data)) DO
       ok := BlockNew(b.next);


### PR DESCRIPTION
### Motivation
- Fix incorrect accounting of `b.used` and remaining `size` in `PieceNew` to prevent over-allocation and wrong offsets when a requested piece fits into the current block.

### Description
- Modify `PieceNew` so it only decrements `size` by the remaining block space when the block is filled, and otherwise increments `b.used` by the requested `size` and sets `size` to `0`, eliminating the extra unconditional decrement that caused incorrect tracking.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f4985bb2c8333a676c87509f589c1)